### PR TITLE
feat: Added support for Azure OpenAI and other LLMs in Semantic Kernel

### DIFF
--- a/samples/python/agents/semantickernel/.envexample
+++ b/samples/python/agents/semantickernel/.envexample
@@ -1,0 +1,9 @@
+# For OpenAI
+OPENAI_API_KEY="your_api_key_here"
+OPENAI_CHAT_MODEL_ID="your-model-id"
+
+# For Azure OpenAI (default)
+AZURE_OPENAI_API_KEY="your-azure-api-key-here"
+AZURE_OPENAI_ENDPOINT="https://your-resource.openai.azure.com/"
+AZURE_OPENAI_CHAT_DEPLOYMENT_NAME="your-chat-deployment-name"
+AZURE_OPENAI_API_VERSION="2024-12-01-preview"

--- a/samples/python/agents/semantickernel/README.md
+++ b/samples/python/agents/semantickernel/README.md
@@ -53,12 +53,31 @@ sequenceDiagram
 cd samples/python/agents/semantickernel
 ```
 
-2. **Create an environment file (.env) with your API key and the model ID (e.g., "gpt-4.1"):**:
+2. **Configure environment variables**:
+
+Create a `.env` file based on `.envexample` file. The agent automatically detects whether to use Azure OpenAI or standard OpenAI based on which environment variables are set.
+
+**For OpenAI:**
 
 ```bash
 OPENAI_API_KEY="your_api_key_here"
 OPENAI_CHAT_MODEL_ID="your-model-id"
 ```
+
+**For Azure OpenAI (default):**
+
+```bash
+AZURE_OPENAI_API_KEY="your-azure-api-key-here"
+AZURE_OPENAI_ENDPOINT="https://your-resource.openai.azure.com/"
+AZURE_OPENAI_CHAT_DEPLOYMENT_NAME="your-deployment-name"
+AZURE_OPENAI_API_VERSION="2024-12-01-preview"
+```
+
+> Note: The agent will use Azure OpenAI if all four Azure variables are set, otherwise it will use standard OpenAI if both OpenAI variables are set.
+
+> Note: Other LLMs can be used as well, but you will need to modify the code to use the appropriate AI connector via the chat completion service method. See Semantic Kernel [documentation](https://learn.microsoft.com/en-us/semantic-kernel/concepts/ai-services/chat-completion/?tabs=csharp-AzureOpenAI%2Cpython-AzureOpenAI%2Cjava-AzureOpenAI&pivots=programming-language-python#creating-a-chat-completion-service) for more details on how to configure other AI services.
+
+> Note: For details on environment variables, refer to the [Semantic Kernel AI Service Settings](https://github.com/microsoft/semantic-kernel/blob/main/python/samples/concepts/setup/ALL_SETTINGS.md#semantic-kernel-settings) document.
 
 3. **Set up the Python Environment**:
 

--- a/samples/python/agents/semantickernel/README.md
+++ b/samples/python/agents/semantickernel/README.md
@@ -73,15 +73,19 @@ AZURE_OPENAI_CHAT_DEPLOYMENT_NAME="your-deployment-name"
 AZURE_OPENAI_API_VERSION="2024-12-01-preview"
 ```
 
-> Note: The agent will use Azure OpenAI if all four Azure variables are set, otherwise it will use standard OpenAI if both OpenAI variables are set.
+> [!NOTE]
+> The agent will use Azure OpenAI if all four Azure variables are set, otherwise it will use standard OpenAI if both OpenAI variables are set.
 
-> Note: Other LLMs can be used as well, but you will need to modify the code to use the appropriate AI connector via the chat completion service method. See Semantic Kernel [documentation](https://learn.microsoft.com/en-us/semantic-kernel/concepts/ai-services/chat-completion/?tabs=csharp-AzureOpenAI%2Cpython-AzureOpenAI%2Cjava-AzureOpenAI&pivots=programming-language-python#creating-a-chat-completion-service) for more details on how to configure other AI services.
+> [!NOTE]
+> Other LLMs can be used as well, but you will need to modify the code to use the appropriate AI connector via the chat completion service method. See Semantic Kernel [documentation](https://learn.microsoft.com/en-us/semantic-kernel/concepts/ai-services/chat-completion/?tabs=csharp-AzureOpenAI%2Cpython-AzureOpenAI%2Cjava-AzureOpenAI&pivots=programming-language-python#creating-a-chat-completion-service) for more details on how to configure other AI services.
 
-> Note: For details on environment variables, refer to the [Semantic Kernel AI Service Settings](https://github.com/microsoft/semantic-kernel/blob/main/python/samples/concepts/setup/ALL_SETTINGS.md#semantic-kernel-settings) document.
+> [!NOTE]
+> For details on environment variables, refer to the [Semantic Kernel AI Service Settings](https://github.com/microsoft/semantic-kernel/blob/main/python/samples/concepts/setup/ALL_SETTINGS.md#semantic-kernel-settings) document.
 
 3. **Set up the Python Environment**:
 
-> Note: pin the Python version to your desired version (3.10+)
+> [!NOTE]
+> pin the Python version to your desired version (3.10+)
 
 ```bash
 uv python pin 3.12
@@ -92,6 +96,7 @@ source .venv/bin/activate
 
 Choose one of the following options:
 
+> [!NOTE]
 > Make sure you run `uv run .` from the following directory: `samples/python/agents/semantickernel`
 
 ```bash
@@ -107,6 +112,7 @@ uv run . --host 0.0.0.0 --port 8080
 
 5. **In a separate terminal, run the A2A client**:
 
+> [!NOTE]
 > Make sure you run `uv run . --agent http://localhost:10020` from the following directory: `samples/python/hosts/cli`
 
 ```bash


### PR DESCRIPTION
# Description

See https://github.com/google-a2a/A2A/pull/505 for more information and background as the previous PR was closed due to the move of a2a-examples folder to a new repo.

Key changes:
1. Enum-based Service Selection: added a ChatServices enum with AZURE_OPENAI and OPENAI options for clear service identification.

2. Added explicity service configuration functions:
- `get_chat_completion_service()`: Main function to get a service by enum value
- `_get_azure_openai_chat_completion_service()`: Handles Azure OpenAI configuration
- `_get_openai_chat_completion_service()`: Handles OpenAI configuration

3. Added auto-detection with fallback using auto_detect_chat_service() function.

4. Provided `.envexample` file for environment variable examples

5. Updated the Readme file with instructions on how to define the variables for each service.

Thanks @moonbox3 for suggestions.

This change makes it possible to add other LLM chat completion services in future.

Cheers, 
 Oliver

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/google/A2A/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [x] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format)
- [x] Appropriate docs were updated (if necessary)

Fixes google-a2a/a2a-samples#45  🦕
