### PR TITLE
fix(samples-js): add required provider.url field for A2A spec compliance

### DIFF
--- a/samples/js/src/agents/coder/index.ts
+++ b/samples/js/src/agents/coder/index.ts
@@ -143,6 +143,7 @@ const coderAgentCard: schema.AgentCard = {
   url: "http://localhost:41241", // Default port used in the script
   provider: {
     organization: "A2A Samples",
+    url: "https://github.com/google-a2a/a2a-samples",
   },
   version: "0.0.1",
   capabilities: {

--- a/samples/js/src/agents/movie-agent/index.ts
+++ b/samples/js/src/agents/movie-agent/index.ts
@@ -137,6 +137,7 @@ const movieAgentCard: schema.AgentCard = {
   url: "http://localhost:41241", // Default port used in the script
   provider: {
     organization: "A2A Samples",
+    url: "https://github.com/google-a2a/a2a-samples"
   },
   version: "0.0.1",
   capabilities: {


### PR DESCRIPTION
# Description
https://github.com/google-a2a/A2A/pull/651
I have moved this pull request to here as requested. 

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Follow the [`CONTRIBUTING` Guide](https://github.com/google-a2a/a2a-samples/blob/main/CONTRIBUTING.md).

Fixes #<issue_number_goes_here> 🦕
