### PR TITLE
fix: set request_id in prep for next rev

### DIFF
--- a/samples/a2a-adk-app/airbnb_agent/test_client.py
+++ b/samples/a2a-adk-app/airbnb_agent/test_client.py
@@ -53,7 +53,7 @@ async def run_single_turn_test(client: A2AClient) -> None:
     send_payload = create_send_message_payload(
         text='Please find a bedroom in new york city, June 15-20, 2025'
     )
-    request = SendMessageRequest(params=MessageSendParams(**send_payload))
+    request = SendMessageRequest(id=str(uuid4()), params=MessageSendParams(**send_payload))
 
     print('--- Single Turn Request ---')
     # Send Message
@@ -70,7 +70,7 @@ async def run_single_turn_test(client: A2AClient) -> None:
     task_id: str = send_response.root.result.id
     print('---Query Task---')
     # query the task
-    get_request = GetTaskRequest(params=TaskQueryParams(id=task_id))
+    get_request = GetTaskRequest(id=str(uuid4()), params=TaskQueryParams(id=task_id))
     get_response: GetTaskResponse = await client.get_task(get_request)
     print_json_response(get_response, 'Query Task Response')
 

--- a/samples/a2a-adk-app/weather_agent/test_client.py
+++ b/samples/a2a-adk-app/weather_agent/test_client.py
@@ -53,7 +53,7 @@ async def run_single_turn_test(client: A2AClient) -> None:
     send_payload = create_send_message_payload(
         text='Please tell me weather in LA, CA'
     )
-    request = SendMessageRequest(params=MessageSendParams(**send_payload))
+    request = SendMessageRequest(id=str(uuid4()), params=MessageSendParams(**send_payload))
 
     print('--- Single Turn Request ---')
     # Send Message
@@ -70,7 +70,7 @@ async def run_single_turn_test(client: A2AClient) -> None:
     task_id: str = send_response.root.result.id
     print('---Query Task---')
     # query the task
-    get_request = GetTaskRequest(params=TaskQueryParams(id=task_id))
+    get_request = GetTaskRequest(id=str(uuid4()), params=TaskQueryParams(id=task_id))
     get_response: GetTaskResponse = await client.get_task(get_request)
     print_json_response(get_response, 'Query Task Response')
 

--- a/samples/python/agents/a2a_mcp/src/a2a_mcp/common/workflow.py
+++ b/samples/python/agents/a2a_mcp/src/a2a_mcp/common/workflow.py
@@ -106,6 +106,7 @@ class WorkflowNode:
                 },
             }
             request = SendStreamingMessageRequest(
+                id=str(uuid4()),
                 params=MessageSendParams(**payload)
             )
             response_stream = client.send_message_streaming(request)

--- a/samples/python/agents/azureaifoundry_sdk/azurefoundryagent/test_client.py
+++ b/samples/python/agents/azureaifoundry_sdk/azurefoundryagent/test_client.py
@@ -155,6 +155,7 @@ async def main() -> None:
             try:
                 # Test regular message sending
                 request = SendMessageRequest(
+                    id=str(uuid4()),
                     params=MessageSendParams(**send_message_payload)
                 )
                 
@@ -165,6 +166,7 @@ async def main() -> None:
                 # Test streaming message sending
                 logger.info("🌊 Testing streaming response...")
                 streaming_request = SendStreamingMessageRequest(
+                    id=str(uuid4()),
                     params=MessageSendParams(**send_message_payload)
                 )
                 

--- a/samples/python/agents/birthday_planner_adk/birthday_planner/adk_agent_executor.py
+++ b/samples/python/agents/birthday_planner_adk/birthday_planner/adk_agent_executor.py
@@ -207,7 +207,7 @@ class ADKAgentExecutor(AgentExecutor):
             while not self._is_task_complete(dependent_task):
                 await asyncio.sleep(AUTH_TASK_POLLING_DELAY_SECONDS)
                 response = await a2a_client.get_task(
-                    GetTaskRequest(params=TaskQueryParams(id=dependent_task.id))
+                    GetTaskRequest(id=str(uuid4()), params=TaskQueryParams(id=dependent_task.id))
                 )
                 if not isinstance(response.root, GetTaskSuccessResponse):
                     logger.debug('Getting dependent task failed: %s', response)
@@ -260,6 +260,7 @@ class ADKAgentExecutor(AgentExecutor):
         # - If the last response from the calendar agent (in this session) produced a non-terminal
         #   task state, the request references that task.
         request = SendMessageRequest(
+            id=str(uuid4()),
             params=MessageSendParams(
                 message=Message(
                     contextId=tool_context._invocation_context.session.id,

--- a/samples/python/agents/headless_agent_auth/test_client.py
+++ b/samples/python/agents/headless_agent_auth/test_client.py
@@ -99,7 +99,7 @@ async def cli(agent: str, context_id: str | None, history: bool, debug: bool):
             if history and continue_loop:
                 print('========= History ======== ')
                 get_task_response = await client.get_task(
-                    GetTaskRequest(params=TaskQueryParams(**{'id': task_id, 'historyLength': 10}))
+                    GetTaskRequest(id=str(uuid4()), params=TaskQueryParams(**{'id': task_id, 'historyLength': 10}))
                 )
                 print(
                     get_task_response.root.model_dump_json(
@@ -154,7 +154,7 @@ async def complete_task(
 
     task = None
     if streaming:
-        stream_response = client.send_message_streaming(SendStreamingMessageRequest(params=send_params))
+        stream_response = client.send_message_streaming(SendStreamingMessageRequest(id=str(uuid4()), params=send_params))
         async for chunk in stream_response:
             result = chunk.root.result
             print(
@@ -197,10 +197,10 @@ async def complete_task(
                 )
             )
         
-        get_task_response = await client.get_task(GetTaskRequest(params=TaskQueryParams(**{'id': task_id})))
+        get_task_response = await client.get_task(GetTaskRequest(id=str(uuid4()), params=TaskQueryParams(id=task_id)))
         task = get_task_response.root.result
     else:
-        send_message_response = await client.send_message(SendMessageRequest(params=send_params))
+        send_message_response = await client.send_message(SendMessageRequest(id=str(uuid4()), params=send_params))
         task = send_message_response.root.result
         print(f'\n{task.model_dump_json(exclude_none=True)}')
 

--- a/samples/python/agents/helloworld/test_client.py
+++ b/samples/python/agents/helloworld/test_client.py
@@ -75,6 +75,7 @@ async def main() -> None:
             },
         }
         request = SendMessageRequest(
+            id=str(uuid4()),
             params=MessageSendParams(**send_message_payload)
         )
 
@@ -82,6 +83,7 @@ async def main() -> None:
         print(response.model_dump(mode='json', exclude_none=True))
        
         streaming_request = SendStreamingMessageRequest(
+                id=str(uuid4()),
                 params=MessageSendParams(**send_message_payload)
             )
 

--- a/samples/python/hosts/multiagent/remote_agent_connection.py
+++ b/samples/python/hosts/multiagent/remote_agent_connection.py
@@ -12,7 +12,7 @@ from a2a.types import (
     SendStreamingMessageRequest,
     JSONRPCErrorResponse,
 )
-
+from uuid import uuid4
 
 TaskCallbackArg = Task | TaskStatusUpdateEvent | TaskArtifactUpdateEvent
 TaskUpdateCallback = Callable[[TaskCallbackArg, AgentCard], Task]
@@ -37,7 +37,7 @@ class RemoteAgentConnections:
         if self.card.capabilities.streaming:
             task = None
             async for response in self.agent_client.send_message_streaming(
-                SendStreamingMessageRequest(params=request)
+                SendStreamingMessageRequest(id=str(uuid4()), params=request)
             ):
                 if not response.root.result:
                     return response.root.error
@@ -54,7 +54,7 @@ class RemoteAgentConnections:
             return task
         else:  # Non-streaming
             response = await self.agent_client.send_message(
-                SendMessageRequest(params=request)
+                SendMessageRequest(id=str(uuid4()), params=request)
             )
             if isinstance(response.root, JSONRPCErrorResponse):
                 return response.root.error


### PR DESCRIPTION
As of current version of the SDK, id attribute in A2A request types is optional. This will be required with the next version of the SDK with the changes part of https://github.com/google-a2a/a2a-python/pull/126.

This change will ensure that the existing request objects have this id value set.
