### PR TITLE
chore: Update the calendar agent to show how server auth can work

### DIFF
--- a/samples/python/agents/birthday_planner_adk/calendar_agent/README.md
+++ b/samples/python/agents/birthday_planner_adk/calendar_agent/README.md
@@ -2,6 +2,8 @@
 
 This example shows how to create an A2A Server that uses an ADK-based Agent that uses Google-authenticated tools.
 
+This agent also provides an example of how to use server authentication. If an incoming request contains a JWT, the agent will associate the Calendar API authorization with the `sub` of the token and use it for future requests. This way, if the same user interacts with the agent across multiple sessions, authorization can be resued.
+
 ## Prerequisites
 
 - Python 3.10 or higher
@@ -25,3 +27,17 @@ This example shows how to create an A2A Server that uses an ADK-based Agent that
    ```bash
    uv run .
    ```
+
+## Testing the agent
+
+Try running the CLI host at samples/python/hosts/cli to interact with the agent.
+
+```bash
+uv run . --agent="http://localhost:10007"
+```
+
+To test out providing authentication to the agent, you can use `gcloud` to provide an ID token to the agent.
+
+```bash
+uv run . --agent="http://localhost:10007" --header="Authorization=Bearer $(gcloud auth print-identity-token)"
+```

--- a/samples/python/agents/birthday_planner_adk/calendar_agent/__main__.py
+++ b/samples/python/agents/birthday_planner_adk/calendar_agent/__main__.py
@@ -1,4 +1,3 @@
-import asyncio
 import base64
 import contextlib
 import json
@@ -99,11 +98,9 @@ def main(host: str, port: int):
         securitySchemes=[],
     )
 
-    adk_agent = asyncio.run(
-        create_agent(
-            client_id=os.getenv('GOOGLE_CLIENT_ID'),
-            client_secret=os.getenv('GOOGLE_CLIENT_SECRET'),
-        )
+    adk_agent = create_agent(
+        client_id=os.getenv('GOOGLE_CLIENT_ID'),
+        client_secret=os.getenv('GOOGLE_CLIENT_SECRET'),
     )
     runner = Runner(
         app_name=agent_card.name,

--- a/samples/python/agents/birthday_planner_adk/calendar_agent/__main__.py
+++ b/samples/python/agents/birthday_planner_adk/calendar_agent/__main__.py
@@ -1,4 +1,7 @@
 import asyncio
+import base64
+import contextlib
+import json
 import logging
 import os
 
@@ -19,7 +22,15 @@ from google.adk.sessions import (
     InMemorySessionService,  # type: ignore[import-untyped]
 )
 from starlette.applications import Starlette
-from starlette.requests import Request
+from starlette.authentication import (
+    AuthCredentials,
+    AuthenticationBackend,
+    BaseUser,
+    SimpleUser,
+)
+from starlette.middleware import Middleware
+from starlette.middleware.authentication import AuthenticationMiddleware
+from starlette.requests import HTTPConnection, Request
 from starlette.responses import PlainTextResponse
 from starlette.routing import Route
 
@@ -34,43 +45,66 @@ load_dotenv()
 logging.basicConfig()
 
 
+class InsecureJWTAuthBackend(AuthenticationBackend):
+    """An example implementation of a JWT-based authentication backend."""
+
+    async def authenticate(
+        self, conn: HTTPConnection
+    ) -> tuple[AuthCredentials, BaseUser] | None:
+        # For illustrative purposes only: please validate your JWTs!
+        with contextlib.suppress(Exception):
+            auth_header = conn.headers["Authorization"]
+            jwt = auth_header.split("Bearer ")[1]
+            jwt_claims = jwt.split(".")[1]
+            missing_padding = len(jwt_claims) % 4
+            if missing_padding:
+                jwt_claims += "=" * (4 - missing_padding)
+            payload = base64.urlsafe_b64decode(jwt_claims).decode("utf-8")
+            parsed_payload = json.loads(payload)
+            return AuthCredentials([]), SimpleUser(parsed_payload["sub"])
+        return None
+
+
 @click.command()
-@click.option('--host', 'host', default='localhost')
-@click.option('--port', 'port', default=10007)
+@click.option("--host", "host", default="localhost")
+@click.option("--port", "port", default=10007)
 def main(host: str, port: int):
     # Verify an API key is set.
     # Not required if using Vertex AI APIs.
-    if os.getenv('GOOGLE_GENAI_USE_VERTEXAI') != 'TRUE' and not os.getenv(
-        'GOOGLE_API_KEY'
+    if os.getenv("GOOGLE_GENAI_USE_VERTEXAI") != "TRUE" and not os.getenv(
+        "GOOGLE_API_KEY"
     ):
         raise ValueError(
-            'GOOGLE_API_KEY environment variable not set and '
-            'GOOGLE_GENAI_USE_VERTEXAI is not TRUE.'
+            "GOOGLE_API_KEY environment variable not set and "
+            "GOOGLE_GENAI_USE_VERTEXAI is not TRUE."
         )
 
     skill = AgentSkill(
-        id='check_availability',
-        name='Check Availability',
+        id="check_availability",
+        name="Check Availability",
         description="Checks a user's availability for a time using their Google Calendar",
-        tags=['calendar'],
-        examples=['Am I free from 10am to 11am tomorrow?'],
+        tags=["calendar"],
+        examples=["Am I free from 10am to 11am tomorrow?"],
     )
 
     agent_card = AgentCard(
-        name='Calendar Agent',
+        name="Calendar Agent",
         description="An agent that can manage a user's calendar",
-        url=f'http://{host}:{port}/',
-        version='1.0.0',
-        defaultInputModes=['text'],
-        defaultOutputModes=['text'],
+        url=f"http://{host}:{port}/",
+        version="1.0.0",
+        defaultInputModes=["text"],
+        defaultOutputModes=["text"],
         capabilities=AgentCapabilities(streaming=True),
         skills=[skill],
+        securitySchemes=[],
     )
 
-    adk_agent = asyncio.run(create_agent(
-        client_id=os.getenv('GOOGLE_CLIENT_ID'),
-        client_secret=os.getenv('GOOGLE_CLIENT_SECRET'),
-    ))
+    adk_agent = asyncio.run(
+        create_agent(
+            client_id=os.getenv("GOOGLE_CLIENT_ID"),
+            client_secret=os.getenv("GOOGLE_CLIENT_SECRET"),
+        )
+    )
     runner = Runner(
         app_name=agent_card.name,
         agent=adk_agent,
@@ -82,9 +116,9 @@ def main(host: str, port: int):
 
     async def handle_auth(request: Request) -> PlainTextResponse:
         await agent_executor.on_auth_callback(
-            str(request.query_params.get('state')), str(request.url)
+            str(request.query_params.get("state")), str(request.url)
         )
-        return PlainTextResponse('Authentication successful.')
+        return PlainTextResponse("Authentication successful.")
 
     request_handler = DefaultRequestHandler(
         agent_executor=agent_executor, task_store=InMemoryTaskStore()
@@ -96,15 +130,20 @@ def main(host: str, port: int):
     routes = a2a_app.routes()
     routes.append(
         Route(
-            path='/authenticate',
-            methods=['GET'],
+            path="/authenticate",
+            methods=["GET"],
             endpoint=handle_auth,
         )
     )
-    app = Starlette(routes=routes)
+    app = Starlette(
+        routes=routes,
+        middleware=[
+            Middleware(AuthenticationMiddleware, backend=InsecureJWTAuthBackend())
+        ],
+    )
 
     uvicorn.run(app, host=host, port=port)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/samples/python/agents/birthday_planner_adk/calendar_agent/adk_agent.py
+++ b/samples/python/agents/birthday_planner_adk/calendar_agent/adk_agent.py
@@ -1,10 +1,10 @@
 import datetime
 
-from google.adk.agents import LlmAgent # type: ignore[import-untyped]
-from google.adk.tools.google_api_tool import CalendarToolset # type: ignore[import-untyped]
+from google.adk.agents import LlmAgent  # type: ignore[import-untyped]
+from google.adk.tools.google_api_tool import CalendarToolset  # type: ignore[import-untyped]
 
 
-async def create_agent(client_id, client_secret) -> LlmAgent:
+def create_agent(client_id, client_secret) -> LlmAgent:
     """Constructs the ADK agent."""
     toolset = CalendarToolset(client_id=client_id, client_secret=client_secret)
     return LlmAgent(
@@ -23,5 +23,5 @@ When using the Calendar API tools, use well-formed RFC3339 timestamps.
 
 Today is {datetime.datetime.now()}.
 """,
-        tools=await toolset.get_tools(),
+        tools=[toolset],
     )

--- a/samples/python/agents/birthday_planner_adk/calendar_agent/adk_agent_executor.py
+++ b/samples/python/agents/birthday_planner_adk/calendar_agent/adk_agent_executor.py
@@ -78,7 +78,9 @@ class ADKAgentExecutor(AgentExecutor):
         session = await self._upsert_session(context)
         auth_details = None
         async for event in self.runner.run_async(
-            session_id=session.id, user_id=session.user_id, new_message=new_message
+            session_id=session.id,
+            user_id=session.user_id,
+            new_message=new_message,
         ):
             # This agent is expected to do one of two things:
             # 1. Ask follow-up questions.
@@ -88,14 +90,20 @@ class ADKAgentExecutor(AgentExecutor):
             # 2. The function call required authorization.
             # Ideally we'd have a way to interpret whether the response is a completion for the
             # task or requires follow-up, but I'm not going to bother just yet.
-            if auth_request_function_call := get_auth_request_function_call(event):
+            if auth_request_function_call := get_auth_request_function_call(
+                event
+            ):
                 # Gather details, then suspend.
-                auth_details = self._prepare_auth_request(auth_request_function_call)
-                logger.debug("Yielding auth required response: %s", auth_details.uri)
+                auth_details = self._prepare_auth_request(
+                    auth_request_function_call
+                )
+                logger.debug(
+                    'Yielding auth required response: %s', auth_details.uri
+                )
                 task_updater.update_status(
                     TaskState.auth_required,
                     message=new_agent_text_message(
-                        f"Authorization is required to continue. Visit {auth_details.uri}"
+                        f'Authorization is required to continue. Visit {auth_details.uri}'
                     ),
                 )
                 # Break out of event handling loop -- no more work will be done until the authorization
@@ -103,12 +111,12 @@ class ADKAgentExecutor(AgentExecutor):
                 break
             if event.is_final_response():
                 parts = convert_genai_parts_to_a2a(event.content.parts)
-                logger.debug("Yielding final response: %s", parts)
+                logger.debug('Yielding final response: %s', parts)
                 task_updater.add_artifact(parts)
                 task_updater.complete()
                 break
             if not event.get_function_calls():
-                logger.debug("Yielding update response")
+                logger.debug('Yielding update response')
                 task_updater.update_status(
                     TaskState.working,
                     message=task_updater.new_agent_message(
@@ -116,11 +124,13 @@ class ADKAgentExecutor(AgentExecutor):
                     ),
                 )
             else:
-                logger.debug("Skipping event")
+                logger.debug('Skipping event')
 
         if auth_details:
             # After auth is received, we can continue processing this request.
-            await self._complete_auth_processing(context, auth_details, task_updater)
+            await self._complete_auth_processing(
+                context, auth_details, task_updater
+            )
 
     def _prepare_auth_request(
         self, auth_request_function_call: types.FunctionCall
@@ -129,23 +139,25 @@ class ADKAgentExecutor(AgentExecutor):
         # https://google.github.io/adk-docs/tools/authentication/#2-handling-the-interactive-oauthoidc-flow-client-side
         if not (auth_request_function_call_id := auth_request_function_call.id):
             raise ValueError(
-                f"Cannot get function call id from function call: {auth_request_function_call}"
+                f'Cannot get function call id from function call: {auth_request_function_call}'
             )
         auth_config = get_auth_config(auth_request_function_call)
         if not (auth_config and auth_request_function_call_id):
             raise ValueError(
-                f"Cannot get auth config from function call: {auth_request_function_call}"
+                f'Cannot get auth config from function call: {auth_request_function_call}'
             )
         oauth2_config = auth_config.exchanged_auth_credential.oauth2
         base_auth_uri = oauth2_config.auth_uri
         if not base_auth_uri:
-            raise ValueError(f"Cannot get auth uri from auth config: {auth_config}")
-        redirect_uri = f"{self._card.url}authenticate"
+            raise ValueError(
+                f'Cannot get auth uri from auth config: {auth_config}'
+            )
+        redirect_uri = f'{self._card.url}authenticate'
         oauth2_config.redirect_uri = redirect_uri
         state_token = oauth2_config.state
         future = asyncio.get_running_loop().create_future()
         self._awaiting_auth[state_token] = future
-        auth_request_uri = base_auth_uri + f"&redirect_uri={redirect_uri}"
+        auth_request_uri = base_auth_uri + f'&redirect_uri={redirect_uri}'
         return ADKAuthDetails(
             state=state_token,
             uri=auth_request_uri,
@@ -160,37 +172,39 @@ class ADKAgentExecutor(AgentExecutor):
         auth_details: ADKAuthDetails,
         task_updater: TaskUpdater,
     ) -> None:
-        logger.debug("Waiting for auth event")
+        logger.debug('Waiting for auth event')
         try:
             auth_uri = await asyncio.wait_for(
                 auth_details.future, timeout=auth_receive_timeout_seconds
             )
         except TimeoutError:
-            logger.debug("Timed out waiting for auth, marking task as failed")
+            logger.debug('Timed out waiting for auth, marking task as failed')
             task_updater.update_status(
                 TaskState.failed,
                 message=new_agent_text_message(
-                    "Timed out waiting for authorization.",
+                    'Timed out waiting for authorization.',
                     context_id=context.context_id,
                 ),
             )
             return
-        logger.debug("Auth received, continuing")
+        logger.debug('Auth received, continuing')
         task_updater.update_status(
             TaskState.working,
             message=new_agent_text_message(
-                "Auth received, continuing...", context_id=context.context_id
+                'Auth received, continuing...', context_id=context.context_id
             ),
         )
         del self._awaiting_auth[auth_details.state]
-        oauth2_config = auth_details.auth_config.exchanged_auth_credential.oauth2
+        oauth2_config = (
+            auth_details.auth_config.exchanged_auth_credential.oauth2
+        )
         oauth2_config.auth_response_uri = auth_uri
         auth_content = types.UserContent(
             parts=[
                 types.Part(
                     function_response=types.FunctionResponse(
                         id=auth_details.auth_request_function_call_id,
-                        name="adk_request_credential",
+                        name='adk_request_credential',
                         response=auth_details.auth_config.model_dump(),
                     ),
                 )
@@ -223,7 +237,7 @@ class ADKAgentExecutor(AgentExecutor):
             context,
             updater,
         )
-        logger.debug("[Calendar] execute exiting")
+        logger.debug('[Calendar] execute exiting')
 
     async def cancel(self, context: RequestContext, event_queue: EventQueue):
         # Ideally: kill any ongoing tasks.
@@ -233,7 +247,7 @@ class ADKAgentExecutor(AgentExecutor):
         self._awaiting_auth[state].set_result(uri)
 
     async def _upsert_session(self, context: RequestContext) -> Session:
-        user_id = "anonymous"
+        user_id = 'anonymous'
         if context.call_context and context.call_context.user.is_authenticated:
             user_id = context.call_context.user.user_name
         session = await self.runner.session_service.get_session(
@@ -257,12 +271,12 @@ class ADKAgentExecutor(AgentExecutor):
                 }
             )
             event = Event(
-                invocation_id="preload_auth",
-                author="system",
+                invocation_id='preload_auth',
+                author='system',
                 actions=event_action,
                 timestamp=time.time(),
             )
-            logger.debug("Loaded authorization state: %s", event)
+            logger.debug('Loaded authorization state: %s', event)
             await self.runner.session_service.append_event(session, event)
         return session
 
@@ -287,8 +301,10 @@ class ADKAgentExecutor(AgentExecutor):
         )
         stored_credential = session.state.get(credential_key)
         if stored_credential:
-            self._credentials[context.call_context.user.user_name] = StoredCredential(
-                key=credential_key, credential=stored_credential
+            self._credentials[context.call_context.user.user_name] = (
+                StoredCredential(
+                    key=credential_key, credential=stored_credential
+                )
             )
 
 
@@ -315,8 +331,8 @@ def convert_a2a_part_to_genai(part: Part) -> types.Part:
                     data=part.file.bytes, mime_type=part.file.mime_type
                 )
             )
-        raise ValueError(f"Unsupported file type: {type(part.file)}")
-    raise ValueError(f"Unsupported part type: {type(part)}")
+        raise ValueError(f'Unsupported file type: {type(part.file)}')
+    raise ValueError(f'Unsupported part type: {type(part)}')
 
 
 def convert_genai_parts_to_a2a(parts: list[types.Part]) -> list[Part]:
@@ -348,7 +364,7 @@ def convert_genai_part_to_a2a(part: types.Part) -> Part:
                 )
             )
         )
-    raise ValueError(f"Unsupported part type: {part}")
+    raise ValueError(f'Unsupported part type: {part}')
 
 
 def get_auth_request_function_call(event: Event) -> types.FunctionCall:
@@ -359,7 +375,7 @@ def get_auth_request_function_call(event: Event) -> types.FunctionCall:
         if (
             part
             and part.function_call
-            and part.function_call.name == "adk_request_credential"
+            and part.function_call.name == 'adk_request_credential'
             and event.long_running_tool_ids
             and part.function_call.id in event.long_running_tool_ids
         ):
@@ -372,9 +388,9 @@ def get_auth_config(
 ) -> AuthConfig:
     """Extracts the AuthConfig object from the arguments of the auth request function call."""
     if not auth_request_function_call.args or not (
-        auth_config := auth_request_function_call.args.get("authConfig")
+        auth_config := auth_request_function_call.args.get('authConfig')
     ):
         raise ValueError(
-            f"Cannot get auth config from function call: {auth_request_function_call}"
+            f'Cannot get auth config from function call: {auth_request_function_call}'
         )
     return AuthConfig.model_validate(auth_config)

--- a/samples/python/agents/birthday_planner_adk/calendar_agent/adk_agent_executor.py
+++ b/samples/python/agents/birthday_planner_adk/calendar_agent/adk_agent_executor.py
@@ -1,14 +1,17 @@
 # mypy: ignore-errors
 import asyncio
 import logging
+import time
 
-from collections import namedtuple
-from collections.abc import AsyncGenerator
-from urllib.parse import parse_qs, urlparse
+from typing import NamedTuple
 
 from google.adk import Runner
-from google.adk.auth import AuthConfig
-from google.adk.events import Event
+from google.adk.auth import AuthConfig, AuthCredential, AuthScheme
+from google.adk.events import Event, EventActions
+from google.adk.sessions import Session
+from google.adk.tools.openapi_tool.openapi_spec_parser.tool_auth_handler import (
+    ToolContextCredentialStore,
+)
 from google.genai import types
 
 from a2a.server.agent_execution import AgentExecutor
@@ -32,10 +35,23 @@ from a2a.utils.message import new_agent_text_message
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
-ADKAuthDetails = namedtuple(
-    'ADKAuthDetails',
-    ['state', 'uri', 'future', 'auth_config', 'auth_request_function_call_id'],
-)
+
+class ADKAuthDetails(NamedTuple):
+    """Contains a collection of properties related to handling ADK authentication."""
+
+    state: str
+    uri: str
+    future: asyncio.Future
+    auth_config: AuthConfig
+    auth_request_function_call_id: str
+
+
+class StoredCredential(NamedTuple):
+    """Contains OAuth2 credentials."""
+
+    key: str
+    credential: AuthCredential
+
 
 # 1 minute timeout to keep the demo moving.
 auth_receive_timeout_seconds = 60
@@ -45,32 +61,25 @@ class ADKAgentExecutor(AgentExecutor):
     """An AgentExecutor that runs an ADK-based Agent."""
 
     _awaiting_auth: dict[str, asyncio.Future]
+    _credentials: dict[str, StoredCredential]
 
     def __init__(self, runner: Runner, card: AgentCard):
         self.runner = runner
         self._card = card
         self._awaiting_auth = {}
-        self._running_sessions = {}
-
-    def _run_agent(
-        self, session_id, new_message: types.Content
-    ) -> AsyncGenerator[Event]:
-        return self.runner.run_async(
-            session_id=session_id, user_id='self', new_message=new_message
-        )
+        self._credentials = {}
 
     async def _process_request(
         self,
         new_message: types.Content,
-        session_id: str,
+        context: RequestContext,
         task_updater: TaskUpdater,
     ) -> None:
-        session = await self._upsert_session(
-            session_id,
-        )
-        session_id = session.id
+        session = await self._upsert_session(context)
         auth_details = None
-        async for event in self._run_agent(session_id, new_message):
+        async for event in self.runner.run_async(
+            session_id=session.id, user_id=session.user_id, new_message=new_message
+        ):
             # This agent is expected to do one of two things:
             # 1. Ask follow-up questions.
             # 2. Call the calendar tool and interpret the results.
@@ -79,20 +88,14 @@ class ADKAgentExecutor(AgentExecutor):
             # 2. The function call required authorization.
             # Ideally we'd have a way to interpret whether the response is a completion for the
             # task or requires follow-up, but I'm not going to bother just yet.
-            if auth_request_function_call := get_auth_request_function_call(
-                event
-            ):
+            if auth_request_function_call := get_auth_request_function_call(event):
                 # Gather details, then suspend.
-                auth_details = self._prepare_auth_request(
-                    auth_request_function_call
-                )
-                logger.debug(
-                    'Yielding auth required response: %s', auth_details.uri
-                )
+                auth_details = self._prepare_auth_request(auth_request_function_call)
+                logger.debug("Yielding auth required response: %s", auth_details.uri)
                 task_updater.update_status(
                     TaskState.auth_required,
                     message=new_agent_text_message(
-                        f'Authorization is required to continue. Visit {auth_details.uri}'
+                        f"Authorization is required to continue. Visit {auth_details.uri}"
                     ),
                 )
                 # Break out of event handling loop -- no more work will be done until the authorization
@@ -100,12 +103,12 @@ class ADKAgentExecutor(AgentExecutor):
                 break
             if event.is_final_response():
                 parts = convert_genai_parts_to_a2a(event.content.parts)
-                logger.debug('Yielding final response: %s', parts)
+                logger.debug("Yielding final response: %s", parts)
                 task_updater.add_artifact(parts)
                 task_updater.complete()
                 break
             if not event.get_function_calls():
-                logger.debug('Yielding update response')
+                logger.debug("Yielding update response")
                 task_updater.update_status(
                     TaskState.working,
                     message=task_updater.new_agent_message(
@@ -113,13 +116,11 @@ class ADKAgentExecutor(AgentExecutor):
                     ),
                 )
             else:
-                logger.debug('Skipping event')
+                logger.debug("Skipping event")
 
         if auth_details:
             # After auth is received, we can continue processing this request.
-            await self._complete_auth_processing(
-                session_id, auth_details, task_updater
-            )
+            await self._complete_auth_processing(context, auth_details, task_updater)
 
     def _prepare_auth_request(
         self, auth_request_function_call: types.FunctionCall
@@ -128,27 +129,23 @@ class ADKAgentExecutor(AgentExecutor):
         # https://google.github.io/adk-docs/tools/authentication/#2-handling-the-interactive-oauthoidc-flow-client-side
         if not (auth_request_function_call_id := auth_request_function_call.id):
             raise ValueError(
-                f'Cannot get function call id from function call: {auth_request_function_call}'
+                f"Cannot get function call id from function call: {auth_request_function_call}"
             )
         auth_config = get_auth_config(auth_request_function_call)
         if not (auth_config and auth_request_function_call_id):
             raise ValueError(
-                f'Cannot get auth config from function call: {auth_request_function_call}'
+                f"Cannot get auth config from function call: {auth_request_function_call}"
             )
         oauth2_config = auth_config.exchanged_auth_credential.oauth2
         base_auth_uri = oauth2_config.auth_uri
         if not base_auth_uri:
-            raise ValueError(
-                f'Cannot get auth uri from auth config: {auth_config}'
-            )
-        redirect_uri = f'{self._card.url}authenticate'
+            raise ValueError(f"Cannot get auth uri from auth config: {auth_config}")
+        redirect_uri = f"{self._card.url}authenticate"
         oauth2_config.redirect_uri = redirect_uri
-        parsed_auth_uri = urlparse(base_auth_uri)
-        query_params_dict = parse_qs(parsed_auth_uri.query)
-        state_token = query_params_dict['state'][0]
+        state_token = oauth2_config.state
         future = asyncio.get_running_loop().create_future()
         self._awaiting_auth[state_token] = future
-        auth_request_uri = base_auth_uri + f'&redirect_uri={redirect_uri}'
+        auth_request_uri = base_auth_uri + f"&redirect_uri={redirect_uri}"
         return ADKAuthDetails(
             state=state_token,
             uri=auth_request_uri,
@@ -159,49 +156,54 @@ class ADKAgentExecutor(AgentExecutor):
 
     async def _complete_auth_processing(
         self,
-        session_id: str,
+        context: RequestContext,
         auth_details: ADKAuthDetails,
         task_updater: TaskUpdater,
     ) -> None:
-        logger.debug('Waiting for auth event')
+        logger.debug("Waiting for auth event")
         try:
             auth_uri = await asyncio.wait_for(
                 auth_details.future, timeout=auth_receive_timeout_seconds
             )
         except TimeoutError:
-            logger.debug('Timed out waiting for auth, marking task as failed')
+            logger.debug("Timed out waiting for auth, marking task as failed")
             task_updater.update_status(
                 TaskState.failed,
                 message=new_agent_text_message(
-                    'Timed out waiting for authorization.',
-                    context_id=session_id,
+                    "Timed out waiting for authorization.",
+                    context_id=context.context_id,
                 ),
             )
             return
-        logger.debug('Auth received, continuing')
+        logger.debug("Auth received, continuing")
         task_updater.update_status(
             TaskState.working,
             message=new_agent_text_message(
-                'Auth received, continuing...', context_id=session_id
+                "Auth received, continuing...", context_id=context.context_id
             ),
         )
         del self._awaiting_auth[auth_details.state]
-        oauth2_config = (
-            auth_details.auth_config.exchanged_auth_credential.oauth2
-        )
+        oauth2_config = auth_details.auth_config.exchanged_auth_credential.oauth2
         oauth2_config.auth_response_uri = auth_uri
         auth_content = types.UserContent(
             parts=[
                 types.Part(
                     function_response=types.FunctionResponse(
                         id=auth_details.auth_request_function_call_id,
-                        name='adk_request_credential',
+                        name="adk_request_credential",
                         response=auth_details.auth_config.model_dump(),
                     ),
                 )
             ]
         )
-        await self._process_request(auth_content, session_id, task_updater)
+        await self._process_request(auth_content, context, task_updater)
+        # Extract the stored credential.
+        if context.call_context and context.call_context.user.is_authenticated:
+            await self._store_user_auth(
+                context,
+                auth_details.auth_config.auth_scheme,
+                auth_details.auth_config.raw_auth_credential,
+            )
 
     async def execute(
         self,
@@ -218,10 +220,10 @@ class ADKAgentExecutor(AgentExecutor):
             types.UserContent(
                 parts=convert_a2a_parts_to_genai(context.message.parts),
             ),
-            context.context_id,
+            context,
             updater,
         )
-        logger.debug('[Calendar] execute exiting')
+        logger.debug("[Calendar] execute exiting")
 
     async def cancel(self, context: RequestContext, event_queue: EventQueue):
         # Ideally: kill any ongoing tasks.
@@ -230,12 +232,64 @@ class ADKAgentExecutor(AgentExecutor):
     async def on_auth_callback(self, state: str, uri: str):
         self._awaiting_auth[state].set_result(uri)
 
-    async def _upsert_session(self, session_id: str):
-        return await self.runner.session_service.get_session(
-            app_name=self.runner.app_name, user_id='self', session_id=session_id
+    async def _upsert_session(self, context: RequestContext) -> Session:
+        user_id = "anonymous"
+        if context.call_context and context.call_context.user.is_authenticated:
+            user_id = context.call_context.user.user_name
+        session = await self.runner.session_service.get_session(
+            app_name=self.runner.app_name,
+            user_id=user_id,
+            session_id=context.context_id,
         ) or await self.runner.session_service.create_session(
-            app_name=self.runner.app_name, user_id='self', session_id=session_id
+            app_name=self.runner.app_name,
+            user_id=user_id,
+            session_id=context.context_id,
         )
+        return await self._ensure_auth(session)
+
+    async def _ensure_auth(self, session: Session) -> Session:
+        if (
+            stored_cred := self._credentials.get(session.user_id)
+        ) and not session.state.get(stored_cred.key):
+            event_action = EventActions(
+                state_delta={
+                    stored_cred.key: stored_cred.credential,
+                }
+            )
+            event = Event(
+                invocation_id="preload_auth",
+                author="system",
+                actions=event_action,
+                timestamp=time.time(),
+            )
+            logger.debug("Loaded authorization state: %s", event)
+            await self.runner.session_service.append_event(session, event)
+        return session
+
+    async def _store_user_auth(
+        self,
+        context: RequestContext,
+        auth_scheme: AuthScheme,
+        raw_credential: AuthCredential,
+    ) -> None:
+        # This reaches into some _deep_ implementation details about the
+        # Google API toolsets. We're going to reach into the session state
+        # and pull out the credential stored by the tool, hoist that into
+        # our per-user credential store. Later, we'll load new sessions
+        # for this user with this special credential key.
+        session = await self._upsert_session(context)
+        # ToolContextCredentialStore doesn't require the tool context to
+        # get the credential key, so we can just pass None (yikes).
+        tool_credential_store = ToolContextCredentialStore(None)
+        credential_key = tool_credential_store.get_credential_key(
+            auth_scheme,
+            raw_credential,
+        )
+        stored_credential = session.state.get(credential_key)
+        if stored_credential:
+            self._credentials[context.call_context.user.user_name] = StoredCredential(
+                key=credential_key, credential=stored_credential
+            )
 
 
 def convert_a2a_parts_to_genai(parts: list[Part]) -> list[types.Part]:
@@ -261,8 +315,8 @@ def convert_a2a_part_to_genai(part: Part) -> types.Part:
                     data=part.file.bytes, mime_type=part.file.mime_type
                 )
             )
-        raise ValueError(f'Unsupported file type: {type(part.file)}')
-    raise ValueError(f'Unsupported part type: {type(part)}')
+        raise ValueError(f"Unsupported file type: {type(part.file)}")
+    raise ValueError(f"Unsupported part type: {type(part)}")
 
 
 def convert_genai_parts_to_a2a(parts: list[types.Part]) -> list[Part]:
@@ -294,7 +348,7 @@ def convert_genai_part_to_a2a(part: types.Part) -> Part:
                 )
             )
         )
-    raise ValueError(f'Unsupported part type: {part}')
+    raise ValueError(f"Unsupported part type: {part}")
 
 
 def get_auth_request_function_call(event: Event) -> types.FunctionCall:
@@ -305,7 +359,7 @@ def get_auth_request_function_call(event: Event) -> types.FunctionCall:
         if (
             part
             and part.function_call
-            and part.function_call.name == 'adk_request_credential'
+            and part.function_call.name == "adk_request_credential"
             and event.long_running_tool_ids
             and part.function_call.id in event.long_running_tool_ids
         ):
@@ -318,9 +372,9 @@ def get_auth_config(
 ) -> AuthConfig:
     """Extracts the AuthConfig object from the arguments of the auth request function call."""
     if not auth_request_function_call.args or not (
-        auth_config := auth_request_function_call.args.get('authConfig')
+        auth_config := auth_request_function_call.args.get("authConfig")
     ):
         raise ValueError(
-            f'Cannot get auth config from function call: {auth_request_function_call}'
+            f"Cannot get auth config from function call: {auth_request_function_call}"
         )
     return AuthConfig.model_validate(auth_config)

--- a/samples/python/hosts/cli/__main__.py
+++ b/samples/python/hosts/cli/__main__.py
@@ -31,27 +31,30 @@ from common.utils.push_notification_auth import PushNotificationReceiverAuth
 
 
 @click.command()
-@click.option('--agent', default='http://localhost:10000')
-@click.option('--session', default=0)
-@click.option('--history', default=False)
-@click.option('--use_push_notifications', default=False)
-@click.option('--push_notification_receiver', default='http://localhost:5000')
+@click.option("--agent", default="http://localhost:10000")
+@click.option("--session", default=0)
+@click.option("--history", default=False)
+@click.option("--use_push_notifications", default=False)
+@click.option("--push_notification_receiver", default="http://localhost:5000")
+@click.option("--header", multiple=True)
 async def cli(
     agent,
     session,
     history,
     use_push_notifications: bool,
     push_notification_receiver: str,
+    header,
 ):
-    async with httpx.AsyncClient(timeout=30) as httpx_client:
+    headers = {h.split("=")[0]: h.split("=")[1] for h in header}
+    print(f"Will use headers: {headers}")
+    async with httpx.AsyncClient(timeout=30, headers=headers) as httpx_client:
         card_resolver = A2ACardResolver(httpx_client, agent)
         card = await card_resolver.get_agent_card()
 
-        print('======= Agent Card ========')
+        print("======= Agent Card ========")
         print(card.model_dump_json(exclude_none=True))
 
-        notif_receiver_parsed = urllib.parse.urlparse(
-            push_notification_receiver)
+        notif_receiver_parsed = urllib.parse.urlparse(push_notification_receiver)
         notification_receiver_host = notif_receiver_parsed.hostname
         notification_receiver_port = notif_receiver_parsed.port
 
@@ -61,9 +64,7 @@ async def cli(
             )
 
             notification_receiver_auth = PushNotificationReceiverAuth()
-            await notification_receiver_auth.load_jwks(
-                f'{agent}/.well-known/jwks.json'
-            )
+            await notification_receiver_auth.load_jwks(f"{agent}/.well-known/jwks.json")
 
             push_notification_listener = PushNotificationListener(
                 host=notification_receiver_host,
@@ -76,28 +77,27 @@ async def cli(
 
         continue_loop = True
         streaming = card.capabilities.streaming
+        context_id = session if session > 0 else uuid4().hex
 
         while continue_loop:
-            print('=========  starting a new task ======== ')
-            continue_loop, contextId, taskId = await completeTask(
+            print("=========  starting a new task ======== ")
+            continue_loop, _, taskId = await completeTask(
                 client,
                 streaming,
                 use_push_notifications,
                 notification_receiver_host,
                 notification_receiver_port,
                 None,
-                None,
+                context_id,
             )
 
             if history and continue_loop:
-                print('========= history ======== ')
+                print("========= history ======== ")
                 task_response = await client.get_task(
-                    {'id': taskId, 'historyLength': 10}
+                    {"id": taskId, "historyLength": 10}
                 )
                 print(
-                    task_response.model_dump_json(
-                        include={'result': {'history': True}}
-                    )
+                    task_response.model_dump_json(include={"result": {"history": True}})
                 )
 
 
@@ -111,13 +111,13 @@ async def completeTask(
     contextId,
 ):
     prompt = click.prompt(
-        '\nWhat do you want to send to the agent? (:q or quit to exit)'
+        "\nWhat do you want to send to the agent? (:q or quit to exit)"
     )
-    if prompt == ':q' or prompt == 'quit':
+    if prompt == ":q" or prompt == "quit":
         return False, None, None
 
     message = Message(
-        role='user',
+        role="user",
         parts=[TextPart(text=prompt)],
         messageId=str(uuid4()),
         taskId=taskId,
@@ -125,38 +125,32 @@ async def completeTask(
     )
 
     file_path = click.prompt(
-        'Select a file path to attach? (press enter to skip)',
-        default='',
+        "Select a file path to attach? (press enter to skip)",
+        default="",
         show_default=False,
     )
-    if file_path and file_path.strip() != '':
-        with open(file_path, 'rb') as f:
-            file_content = base64.b64encode(f.read()).decode('utf-8')
+    if file_path and file_path.strip() != "":
+        with open(file_path, "rb") as f:
+            file_content = base64.b64encode(f.read()).decode("utf-8")
             file_name = os.path.basename(file_path)
 
         message.parts.append(
-            Part(
-                root=FilePart(
-                    file=FileWithBytes(
-                        name=file_name, bytes=file_content
-                    )
-                )
-            )
+            Part(root=FilePart(file=FileWithBytes(name=file_name, bytes=file_content)))
         )
 
     payload = MessageSendParams(
         id=str(uuid4()),
         message=message,
         configuration=MessageSendConfiguration(
-            acceptedOutputModes=['text'],
+            acceptedOutputModes=["text"],
         ),
     )
 
     if use_push_notifications:
-        payload['pushNotification'] = {
-            'url': f'http://{notification_receiver_host}:{notification_receiver_port}/notify',
-            'authentication': {
-                'schemes': ['bearer'],
+        payload["pushNotification"] = {
+            "url": f"http://{notification_receiver_host}:{notification_receiver_port}/notify",
+            "authentication": {
+                "schemes": ["bearer"],
             },
         }
 
@@ -175,19 +169,15 @@ async def completeTask(
                 return False, contextId, taskId
             event = result.root.result
             contextId = event.contextId
-            if (
-                isinstance(event, Task)
-            ):
+            if isinstance(event, Task):
                 taskId = event.id
-            elif (isinstance(event, TaskStatusUpdateEvent)
-                  or isinstance(event, TaskArtifactUpdateEvent)
+            elif isinstance(event, TaskStatusUpdateEvent) or isinstance(
+                event, TaskArtifactUpdateEvent
             ):
                 taskId = event.taskId
             elif isinstance(event, Message):
                 message = event
-            print(
-                f'stream event => {event.model_dump_json(exclude_none=True)}'
-            )
+            print(f"stream event => {event.model_dump_json(exclude_none=True)}")
         # Upon completion of the stream. Retrieve the full task if one was made.
         if taskId:
             taskResult = await client.get_task(
@@ -219,7 +209,7 @@ async def completeTask(
             message = event
 
     if message:
-        print(f'\n{message.model_dump_json(exclude_none=True)}')
+        print(f"\n{message.model_dump_json(exclude_none=True)}")
         return True, contextId, taskId
     if taskResult:
         # Don't print the contents of a file.
@@ -228,14 +218,14 @@ async def completeTask(
                 "history": {
                     "__all__": {
                         "parts": {
-                            "__all__" : {"file"},
+                            "__all__": {"file"},
                         },
                     },
                 },
             },
             exclude_none=True,
         )
-        print(f'\n{task_content}')
+        print(f"\n{task_content}")
         ## if the result is that more input is required, loop again.
         state = TaskState(taskResult.status.state)
         if state.name == TaskState.input_required.name:
@@ -258,5 +248,5 @@ async def completeTask(
     return True, contextId, taskId
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     asyncio.run(cli())


### PR DESCRIPTION
# Description

This updates the ADK Calendar Agent to support storing credentials per-user, rather than just per-session. It does so by introducing an extremely simple JWT authentication layer that identifies incoming `sub` claims on an unvalidated, unverified JWT. This then gets the `ServerCallContext.user` field correctly populated, which we can then use to setup an in-memory, user-keyed credential store.


Depends on google-a2a/a2a-python#133