### PR TITLE
add: python requirements.txt file

### DIFF
--- a/samples/python/requirements.txt
+++ b/samples/python/requirements.txt
@@ -1,0 +1,2 @@
+a2a-sdk>=latest
+uvicorn>=latest


### PR DESCRIPTION
# Description

This will streamline python dependencies going forward and will currently prevent error for the Start Server step for not having uvicorn installed. Will update docs repo steps and ref this PR.
