### PR TITLE
Allow both http and https URLs when fetching AgentCard

### DIFF
--- a/demo/ui/utils/agent_card.py
+++ b/demo/ui/utils/agent_card.py
@@ -5,7 +5,9 @@ from a2a.types import AgentCard
 
 def get_agent_card(remote_agent_address: str) -> AgentCard:
     """Get the agent card."""
+    if not remote_agent_address.startswith(('http://', 'https://')):
+        raise ValueError("remote_agent_address must start with http:// or https://")
     agent_card = requests.get(
-        f'http://{remote_agent_address}/.well-known/agent.json'
+        f'{remote_agent_address}/.well-known/agent.json'
     )
     return AgentCard(**agent_card.json())

--- a/demo/ui/utils/agent_card.py
+++ b/demo/ui/utils/agent_card.py
@@ -6,7 +6,7 @@ from a2a.types import AgentCard
 def get_agent_card(remote_agent_address: str) -> AgentCard:
     """Get the agent card."""
     if not remote_agent_address.startswith(('http://', 'https://')):
-        raise ValueError("remote_agent_address must start with http:// or https://")
+        remote_agent_address = 'http://' + remote_agent_address
     agent_card = requests.get(
         f'{remote_agent_address}/.well-known/agent.json'
     )


### PR DESCRIPTION
# Description

This PR updates the validation logic for fetching the AgentCard to allow both `http://` and `https://` URLs, instead of only supporting `http://`. This improves compatibility with agents served over HTTPS.

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/google-a2a/a2a-samples/blob/main/CONTRIBUTING.md).

Fixes #<issue_number_goes_here> 🦕