### PR TITLE
Fix event loop closed error when processing messages from threads

### DIFF
--- a/demo/ui/service/server/adk_host_manager.py
+++ b/demo/ui/service/server/adk_host_manager.py
@@ -7,6 +7,7 @@ import uuid
 from typing import Optional, Tuple
 
 import httpx
+import asyncio
 
 from a2a.types import (
     AgentCard,
@@ -618,6 +619,11 @@ class ADKHostManager(ApplicationManager):
                 Part(root=DataPart(data=part.function_response.model_dump()))
             )
         return parts
+
+    def process_message_threadsafe(self, message: Message, loop: asyncio.AbstractEventLoop):
+        """Safely run process_message from a thread using the given event loop."""
+        future = asyncio.run_coroutine_threadsafe(self.process_message(message), loop)
+        return future  # You can call future.result() to get the result if needed
 
 
 def get_message_id(m: Message | None) -> str | None:


### PR DESCRIPTION
- Use process_message_threadsafe with the main event loop instead of asyncio.run() in threads
- Use typing.cast to avoid type errors with ApplicationManager

# Description
Description
This PR improves thread safety when processing messages asynchronously in ADKHostManager.

Added process_message_threadsafe method to safely execute process_message from a thread using the main event loop.
This change prevents RuntimeError: Event loop is closed when sending messages from threads.


- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/google-a2a/a2a-samples/blob/main/CONTRIBUTING.md).

Fixes #<issue_number_goes_here> 🦕
