### PR TITLE
Fix host agent missing error

### DIFF
--- a/samples/python/hosts/multiagent/host_agent.py
+++ b/samples/python/hosts/multiagent/host_agent.py
@@ -46,6 +46,7 @@ class HostAgent:
         self.remote_agent_connections: dict[str, RemoteAgentConnections] = {}
         self.cards: dict[str, AgentCard] = {}
         task_group = asyncio.TaskGroup()
+        self.agents: str = ''
         for address in remote_agent_addresses:
             task_group.create_task(self.retrieve_card(address))
         # The task groups run in the background and complete.

--- a/samples/python/hosts/multiagent/host_agent.py
+++ b/samples/python/hosts/multiagent/host_agent.py
@@ -54,7 +54,7 @@ class HostAgent:
         # connections are established.
 
     async def retrieve_card(self, address: str):
-        card_resolver = A2ACardResolver(self.http_client, address)
+        card_resolver = A2ACardResolver(self.httpx_client, address)
         card = await card_resolver.get_agent_card()
         self.register_agent_card(card)
 


### PR DESCRIPTION
# Description

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/google-a2a/a2a-samples/blob/main/CONTRIBUTING.md).

Fixes #13, unsure but possibly related to other issues involving demo not working (#66, #6 ) 🦕

- Fixes bug occurring in the demo where creating a HostAgent without remote agents causes a failure in `HostAgent:root_instruction()`.
  - `root_instruction()` accesses the instance attribute `self.agents`, a newline-separated string listing the names of remote agents. However, if there are no remote agent address passed to HostAgent during initialization, as is the case with ADKHostManager used in the demo, then `self.agents` is never initialized, resulting in errors until a remote agent is added.
- Also fixes a bug where the wrong variable name is used (`http_client`) in `HostAgent:retrieve_card()`.